### PR TITLE
augment_manta_vcf version 1.0

### DIFF
--- a/augment_manta_vcf/1.0/augment_manta_vcf.py
+++ b/augment_manta_vcf/1.0/augment_manta_vcf.py
@@ -4,16 +4,30 @@
 augment_manta_vcf.py
 ====================
 
-This script augments Manta VCF files with additional information. Namely:
+This script augments Manta VCF files with additional information. The following
+fields are added to the INFO and FORMAT/SAMPLE columns where applicable:
+
     1) TR (FORMAT field): Sum of the SR and PR FORMAT fields per allele.
     2) DP (FORMAT field): Sum of the SR and PR FORMAT fields across all alleles.
     3) VAF (FORMAT field): Variant allele fraction for the alternate allele.
     4) REGIONS (INFO field): List of regions from the given BED files that
-       overlap each variant position.
+       overlap each variant position. One example use case is labelling
+       breakpoints occuring in loci of interest such as MYC, BCL2, BCL6,
+       and the three IG loci. This can readily be done downstream, but
+       having the breakpoints labelled in the VCF file can enable quick
+       exploratory analyses.
 
-If also updates the sample IDs in the VCF file with any values specified using
-the `--tumour-id` and `--normal-id` arguments based on the "VCF type" with the
-following rules:
+The script can optionally update the sample IDs in the VCF header, namely
+the row with "#CHROM". Unfortunately, different Manta output VCF files
+include different combinations of the tumour and/or normal samples used
+in the analysis. Based on existing Manta output files, it was found that
+the sample present in the VCF files follow the rules below. The script
+will attempt to infer the "VCF type" (e.g., "somaticSV") based on the
+input VCF file path. If this isn't possible for whatever reason, the
+user can provide a value for the `--vcf_type` argument. Depending on
+the VCF type, the user will need to provide values for `--tumour_id`
+and/or `--normal_id`.
+
     1) candidateSV: No samples
     2) candidateSmallIndels: No samples
     3) rnaSV: Tumour sample only

--- a/augment_manta_vcf/1.0/augment_manta_vcf.py
+++ b/augment_manta_vcf/1.0/augment_manta_vcf.py
@@ -98,7 +98,7 @@ def main():
 
 
 def parse_arguments():
-    """Parses and validate command-line arguments"""
+    """Parses and validates command-line arguments."""
 
     # Parse command-line arguments
     parser = argparse.ArgumentParser()
@@ -202,7 +202,7 @@ def modify_header(vcf, bed_files):
 
 
 def parse_bed_files(bed_files):
-    """Create PyRanges objects from the BED files."""
+    """Creates PyRanges objects from the BED files."""
 
     # Skip if no BED files are provided
     if len(bed_files) == 0:
@@ -227,7 +227,7 @@ def parse_bed_files(bed_files):
 
 
 def get_overlapping_region_names(variant, bed):
-    """Get list of overlapping region names from a BED file."""
+    """Gets list of overlapping region names from a BED file."""
 
     # Generate 0-based region for querying regions
     sv_type = variant.INFO["SVTYPE"]
@@ -253,10 +253,10 @@ def get_overlapping_region_names(variant, bed):
     return overlapping_regions.Name.tolist()
 
 
-def augment_variant(variant, bed, decimals):
-    """Augments the given variant with additional fields.
+def add_fields_to_variant(variant, bed, decimals):
+    """Adds the given variant with additional fields.
 
-    The new fields are described in the top-level doctring.
+    The new fields are described in the top-level docstring.
     """
 
     # Extract split read (sr) and read pair (pr) counts
@@ -300,7 +300,7 @@ def augment_variant(variant, bed, decimals):
 
 
 def augment_vcf(vcf_in_file, vcf_out_file, bed_files, decimals):
-    """Parse and augment VCF file."""
+    """Parses and augments VCF file."""
 
     # Read in the input VCF file
     vcf_in = VCF(vcf_in_file)
@@ -319,7 +319,7 @@ def augment_vcf(vcf_in_file, vcf_out_file, bed_files, decimals):
         # Augment the variant by adding new fields (if there are samples)
         num_samples = len(vcf_in.samples)
         if num_samples > 0:
-            variant = augment_variant(variant, bed, decimals)
+            variant = add_fields_to_variant(variant, bed, decimals)
         # Output the augmented variant
         vcf_out.write_record(variant)
 
@@ -329,7 +329,7 @@ def augment_vcf(vcf_in_file, vcf_out_file, bed_files, decimals):
 
 
 def parse_vcf_type(filename):
-    """Extract VCF type from the file path."""
+    """Extracts VCF type from the file path."""
 
     # Create list of all possible Manta VCF types
     vcf_types = [
@@ -356,7 +356,7 @@ def parse_vcf_type(filename):
 
 
 def update_header_line(line, vcf_type, tumour_id, normal_id):
-    """Update header line based on VCF type.
+    """Updates header line based on VCF type.
 
     See top-level docstring for more details.
     """
@@ -399,7 +399,7 @@ def update_header_line(line, vcf_type, tumour_id, normal_id):
 
 
 def update_sample_ids(vcf_file, vcf_type, tumour_id, normal_id):
-    """Process VCF file to update sample IDs in header."""
+    """Processes VCF file to update sample IDs in header."""
 
     # Skip if both tumour_id and normal_id are None
     if tumour_id is None and normal_id is None:

--- a/augment_manta_vcf/1.0/augment_manta_vcf.py
+++ b/augment_manta_vcf/1.0/augment_manta_vcf.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+
+"""
+augment_manta_vcf.py
+====================
+
+This script augments Manta VCF files with additional information. Namely:
+    1) TR (FORMAT field): Sum of the SR and PR FORMAT fields per allele.
+    2) DP (FORMAT field): Sum of the SR and PR FORMAT fields across all alleles.
+    3) VAF (FORMAT field): Variant allele fraction for the alternate allele.
+    4) REGIONS (INFO field): List of regions overlapping current position.
+
+If also updates the sample IDs in the VCF file with any values specified using
+the `--tumour-id` and `--normal-id` arguments based on the "VCF type" with the
+following rules:
+    1) candidateSV: No samples
+    2) candidateSmallIndels: No samples
+    3) rnaSV: Tumour sample only
+    4) tumorSV: Tumour sample only
+    5) diploidSV: Normal sample only
+    6) somaticSV: Normal sample first and then tumour sample
+
+Inputs
+------
+- Manta VCF file
+
+Outputs
+-------
+- Augmented VCF file
+
+Caveats
+-------
+- This script assumes that the Manta VCF files only contain one alternate
+  allele, even though the VCF header hints that there could be more than
+  one (e.g., "for the ref and alt alleles in the order listed"). Out of
+  hundreds of Manta VCF files, none had more than one alternate allele,
+  so support for more alternate allele won't be added for now.
+- Due to limitations with the `cyvcf2` API, it is not possible to update
+  the sample IDs during the pass when the variants are being processed.
+  Unfortunately, a second pass of the VCF file is required. Updating the
+  sample IDs is done as the second step to avoid dealing with compressed
+  files since cyvcf2 can more easily handle gzip-compressed VCF files.
+"""
+
+
+# Import standard modules
+import os
+import sys
+import warnings
+import argparse
+import tempfile
+
+# Import third-party modules
+import pyranges as pr
+import numpy as np
+from cyvcf2 import VCF, Writer
+
+
+IS_QUIET = False
+
+
+def main():
+    """Runs all of the other functions."""
+
+    # Parse command-line arguments
+    args = parse_arguments()
+
+    # Change verbosity
+    global IS_QUIET
+    IS_QUIET = args.quiet
+
+    # Add new fields to each variant
+    augment_vcf(args.vcf, args.output, args.regions, args.decimals)
+
+    # Parse VCF type if not provided
+    if args.vcf_type is None:
+        args.vcf_type = parse_vcf_type(args.vcf)
+
+    # Update sample IDs (will skip if both are None)
+    update_sample_ids(args.output, args.vcf_type, args.tumour_id, args.normal_id)
+
+
+def parse_arguments():
+    """Parses and validate command-line arguments"""
+
+    # Parse command-line arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("vcf_input", help="Manta VCF file (gzip-compressed or not).")
+    parser.add_argument("output", help="Output (augmented) VCF file.")
+    parser.add_argument(
+        "regions",
+        nargs="*",
+        default=[],
+        help="Regions BED file(s). Names (column 4) must be unique across all files.",
+    )
+    parser.add_argument(
+        "--decimals",
+        "-d",
+        type=int,
+        default=3,
+        help="Number of decimals for rounding.",
+    )
+    parser.add_argument("--tumour_id", "-t", help="Tumour sample ID.")
+    parser.add_argument("--normal_id", "-n", help="Normal sample ID.")
+    parser.add_argument(
+        "--vcf_type",
+        "-v",
+        choices=[
+            "tumorSV",
+            "rnaSV",
+            "somaticSV",
+            "diploidSV",
+            "candidateSmallIndels",
+            "candidateSV",
+        ],
+        help="Manta VCF type.",
+    )
+    parser.add_argument(
+        "--quiet", "-q", action="store_true", help="Silence warnings.",
+    )
+    args = parser.parse_args()
+
+    # Validate command-line arguments
+    assert not args.output.endswith(".gz"), "Cannot output gzip-compressed VCF file."
+
+    return args
+
+
+def modify_header(vcf, bed_files):
+    """Adds info on TR and VAF FORMAT fields to VCF header."""
+
+    # Add FORMAT and INFO field information to header
+    vcf.add_format_to_header(
+        {
+            "ID": "TR",
+            "Description": "Total read support (SR + PR) for the ref and alt alleles in the order listed",
+            "Type": "Float",
+            "Number": ".",
+        }
+    )
+    vcf.add_format_to_header(
+        {
+            "ID": "DP",
+            "Description": "Total read support (SR + PR) for the ref and first alt allele combined",
+            "Type": "Float",
+            "Number": "1",
+        }
+    )
+    vcf.add_format_to_header(
+        {
+            "ID": "VAF",
+            "Description": "Variant allele fraction for the first alt allele",
+            "Type": "Float",
+            "Number": "1",
+        }
+    )
+
+    # Only add info about REGIONS field if at least one BED is given
+    if len(bed_files) > 0:
+        vcf.add_info_to_header(
+            {
+                "ID": "REGIONS",
+                "Description": (
+                    "Overlapping regions from the given BED files "
+                    "(see `##regions_bed` header lines)"
+                ),
+                "Type": "String",
+                "Number": ".",
+            }
+        )
+
+    # Add list of regions BED files to header
+    for bed_file in bed_files:
+        bed_file = os.path.abspath(bed_file)
+        vcf.add_to_header(f"##regions_bed={bed_file}\n")
+
+    # Add command to header
+    sys.argv[0] = os.path.abspath(sys.argv[0])
+    command = " ".join(sys.argv)
+    vcf.add_to_header(f"##cmdline={command}\n")
+
+    return vcf
+
+
+def parse_bed_files(bed_files):
+    """Create PyRanges objects from the BED files."""
+
+    # Skip if no BED files are provided
+    if len(bed_files) == 0:
+        return
+
+    # Load BED files
+    beds = [pr.read_bed(b) for b in bed_files]
+
+    # Check that all BED files have the first four columns
+    for bed_file, bed in zip(bed_files, beds):
+        assert "Name" in bed.columns, f"Name (column 4) missing from {bed_file}."
+
+    # Concatenate BED files and only keep Name column
+    bed = pr.concat(beds)
+    bed = bed.unstrand()
+    bed = bed[["Name"]]
+
+    # Ensure unique names
+    assert bed.Name.is_unique, "Names (column 4) not unique across BED files."
+
+    return bed
+
+
+def get_overlapping_region_names(variant, bed):
+    """Get list of overlapping region names from a BED file."""
+
+    # Generate 0-based region for querying regions
+    sv_type = variant.INFO["SVTYPE"]
+    chrom = variant.CHROM
+    start = variant.POS if sv_type == "INS" else variant.POS - 1
+    end = variant.POS if sv_type == "BND" else variant.INFO["END"]
+    end = end - 1 if sv_type == "INS" else end
+
+    # Get overlapping regions
+    overlapping_regions = bed[chrom, start:end]
+
+    # Return empty list if no overlapping regions are found
+    if len(overlapping_regions) == 0:
+        return []
+
+    # Issue warning if there are many overlapping regions
+    if len(overlapping_regions) > 10 and not IS_QUIET:
+        warnings.warn(
+            "Warning: More than 10 overlapping regions. If this is "
+            "expected, you can silence this warning with `--quiet`."
+        )
+
+    return overlapping_regions.Name.tolist()
+
+
+def augment_variant(variant, bed, decimals):
+    """Augments the given variant with additional fields.
+
+    The new fields are described in the top-level doctring.
+    """
+
+    # Extract split read (sr) and read pair (pr) counts
+    sr = variant.format("SR")
+    pr = variant.format("PR")
+
+    # Fill in any missing fields with zeros
+    if sr is None or pr is None:
+        # Use the same shape as the non-missing field
+        shape = sr.shape if pr is None else pr.shape
+        zeros = np.zeros(shape)
+        sr = zeros if sr is None else sr
+        pr = zeros if pr is None else pr
+
+    # Calculate total read counts (tr)
+    tr = sr + pr
+
+    # Expect two alleles (one REF and one ALT)
+    num_alleles = tr.shape[1]
+    assert num_alleles == 2, "Encountered more than one alternate allele."
+
+    # Calculate allele-specific counts, total depth (dp), and VAF
+    ref_count = tr[:, 0]
+    alt_count = tr[:, 1]
+    dp = ref_count + alt_count
+    vaf = alt_count / dp
+    vaf = vaf.round(decimals)
+
+    # Set the calculated values as FORMAT fields
+    variant.set_format("TR", tr)
+    variant.set_format("DP", dp)
+    variant.set_format("VAF", vaf)
+
+    # Get list of overlapping region names and add if not empty
+    if bed is not None:
+        region_names = get_overlapping_region_names(variant, bed)
+        if len(region_names) > 0:
+            variant.INFO["REGIONS"] = ",".join(region_names)
+
+    return variant
+
+
+def augment_vcf(vcf_in_file, vcf_out_file, bed_files, decimals):
+    """Parse and augment VCF file."""
+
+    # Read in the input VCF file
+    vcf_in = VCF(vcf_in_file)
+
+    # Add rows to the header for each new field
+    vcf_in = modify_header(vcf_in, bed_files)
+
+    # Set up a write based on the tweaked input VCF file
+    vcf_out = Writer(vcf_out_file, vcf_in)
+
+    # Parse BED files
+    bed = parse_bed_files(bed_files)
+
+    # Iterate over every variant record
+    for variant in vcf_in:
+        # Augment the variant by adding new fields (if there are samples)
+        num_samples = len(vcf_in.samples)
+        if num_samples > 0:
+            variant = augment_variant(variant, bed, decimals)
+        # Output the augmented variant
+        vcf_out.write_record(variant)
+
+    # Close input and output VCF files
+    vcf_in.close()
+    vcf_out.close()
+
+
+def parse_vcf_type(filename):
+    """Extract VCF type from the file path."""
+
+    # Create list of all possible Manta VCF types
+    vcf_types = [
+        "candidateSV",
+        "candidateSmallIndels",
+        "diploidSV",
+        "somaticSV",
+        "tumorSV",
+        "rnaSV",
+    ]
+
+    # Filter down for those that appear in the filename
+    vcf_types = filter(lambda x: x in filename, vcf_types)
+    vcf_types = list(vcf_types)
+    num_matches = len(vcf_types)
+
+    # Check that only one match exists
+    assert num_matches == 1, (
+        "Could not infer VCF type from file name. Expected 1 match, but found "
+        f"{num_matches} instead. Please use `--vcf_type` to disambiguate."
+    )
+
+    return vcf_types[0]
+
+
+def update_header_line(line, vcf_type, tumour_id, normal_id):
+    """Update header line based on VCF type.
+
+    See top-level docstring for more details.
+    """
+
+    # Split line into columns
+    columns = line.rstrip("\n").split("\t")
+    num_columns = len(columns)
+
+    # No samples
+    if vcf_type in ["candidateSV", "candidateSmallIndels"]:
+        assert num_columns == 8, f"Expected 8 columns, found {num_columns}."
+
+    # Tumour sample only
+    elif vcf_type in ["rnaSV", "tumorSV"]:
+        assert num_columns == 10, f"Expected 10 columns, found {num_columns}."
+        assert tumour_id is not None, f"`--tumour_id` is required for {vcf_type}."
+        columns[9] = tumour_id
+
+    # Normal sample only
+    elif vcf_type in ["diploidSV"]:
+        assert num_columns == 10, f"Expected 10 columns, found {num_columns}."
+        assert normal_id is not None, f"`--normal_id` is required for {vcf_type}."
+        columns[9] = normal_id
+
+    # Normal sample first and then tumour sample
+    elif vcf_type in ["somaticSV"]:
+        assert num_columns == 11, f"Expected 11 columns, found {num_columns}."
+        assert tumour_id is not None, f"`--tumour_id` is required for {vcf_type}."
+        assert normal_id is not None, f"`--normal_id` is required for {vcf_type}."
+        columns[9] = normal_id
+        columns[10] = tumour_id
+
+    # This shouldn't happen because either it was provided by the user, which
+    # is restricted to the choices given to `argparse`, or it was parsed by
+    # `parse_vcf_type`, which shouldn't return anything unexpected.
+    else:
+        raise Exception(f"Encountered unknown VCF type ({vcf_type}).")
+
+    return "\t".join(columns) + "\n"
+
+
+def update_sample_ids(vcf_file, vcf_type, tumour_id, normal_id):
+    """Process VCF file to update sample IDs in header."""
+
+    # Skip if both tumour_id and normal_id are None
+    if tumour_id is None and normal_id is None:
+        return
+
+    # Open files
+    _, temp_file = tempfile.mkstemp()
+    with open(vcf_file, "r") as vcf, open(temp_file, "w") as temp:
+
+        # Iterate over every line (and only process header)
+        for line in vcf:
+            # Find the header line
+            if line.startswith("#CHROM"):
+                line = update_header_line(line, vcf_type, tumour_id, normal_id)
+            temp.write(line)
+
+    # Replace the old VCF file with the updated file
+    os.replace(temp_file, vcf_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/augment_manta_vcf/1.0/augment_manta_vcf.py
+++ b/augment_manta_vcf/1.0/augment_manta_vcf.py
@@ -8,7 +8,8 @@ This script augments Manta VCF files with additional information. Namely:
     1) TR (FORMAT field): Sum of the SR and PR FORMAT fields per allele.
     2) DP (FORMAT field): Sum of the SR and PR FORMAT fields across all alleles.
     3) VAF (FORMAT field): Variant allele fraction for the alternate allele.
-    4) REGIONS (INFO field): List of regions overlapping current position.
+    4) REGIONS (INFO field): List of regions from the given BED files that
+       overlap each variant position.
 
 If also updates the sample IDs in the VCF file with any values specified using
 the `--tumour-id` and `--normal-id` arguments based on the "VCF type" with the

--- a/augment_manta_vcf/1.0/cyvcf2-0.20.0.yaml
+++ b/augment_manta_vcf/1.0/cyvcf2-0.20.0.yaml
@@ -1,0 +1,1 @@
+../../envs/cyvcf2/cyvcf2-0.20.0.yaml

--- a/envs/cyvcf2/cyvcf2-0.20.0.yaml
+++ b/envs/cyvcf2/cyvcf2-0.20.0.yaml
@@ -1,0 +1,55 @@
+name: test-cyvcf2
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - _libgcc_mutex=0.1
+  - _openmp_mutex=4.5
+  - bzip2=1.0.8
+  - ca-certificates=2020.4.5.1
+  - certifi=2020.4.5.1
+  - click=7.1.2
+  - coloredlogs=14.0
+  - cyvcf2=0.20.0
+  - htslib=1.10.2
+  - humanfriendly=8.2
+  - krb5=1.17.1
+  - ld_impl_linux-64=2.34
+  - libblas=3.8.0
+  - libcblas=3.8.0
+  - libcurl=7.69.1
+  - libdeflate=1.3
+  - libedit=3.1.20170329
+  - libffi=3.2.1
+  - libgcc-ng=9.2.0
+  - libgfortran-ng=7.3.0
+  - liblapack=3.8.0
+  - libopenblas=0.3.9
+  - libssh2=1.8.2
+  - libstdcxx-ng=9.2.0
+  - llvm-openmp=10.0.0
+  - natsort=7.0.1
+  - ncls=0.0.53
+  - ncurses=6.1
+  - numpy=1.18.4
+  - openssl=1.1.1g
+  - pandas=1.0.3
+  - pip=20.1
+  - pyranges=0.0.77
+  - pyrle=0.0.31
+  - python=3.7.6
+  - python-dateutil=2.8.1
+  - python_abi=3.7
+  - pytz=2020.1
+  - readline=8.0
+  - setuptools=46.1.3
+  - six=1.14.0
+  - sorted_nearest=0.0.31
+  - sqlite=3.30.1
+  - tabulate=0.8.7
+  - tk=8.6.10
+  - wheel=0.34.2
+  - xz=5.2.5
+  - zlib=1.2.11
+prefix: /home/bgrande/miniconda3/envs/test-cyvcf2


### PR DESCRIPTION
This script is meant to supersede the `calc_manta_vaf` script, which was written with the `somaticSV` VCF files in mind. Here, `augment_manta_vcf` is more general and can handle all Manta VCF files. It also offers features that will be used in the `manta` lcr-module, such as updating the sample IDs. One of the major differences is that `augment_manta_vcf` uses the `cyvcf2` package as the VCF file parser instead of `pyvcf`, which hasn't been updated in years. The interface for `cyvcf2`, while minimalist, still allowed me to implement the features I was interested in, namely (copied from script docstring):

> This script augments Manta VCF files with additional information. Namely:
>     1) TR (FORMAT field): Sum of the SR and PR FORMAT fields per allele.
>     2) DP (FORMAT field): Sum of the SR and PR FORMAT fields across all alleles.
>     3) VAF (FORMAT field): Variant allele fraction for the alternate allele.
>     4) REGIONS (INFO field): List of regions overlapping current position.
>
> If also updates the sample IDs in the VCF file with any values specified using
> the `--tumour-id` and `--normal-id` arguments based on the "VCF type" with the
> following rules:
>     1) candidateSV: No samples
>     2) candidateSmallIndels: No samples
>     3) rnaSV: Tumour sample only
>     4) tumorSV: Tumour sample only
>     5) diploidSV: Normal sample only
>     6) somaticSV: Normal sample first and then tumour sample

I tested this on over 2000 Manta VCF files and I didn't get any errors. 

**N.B.** The script was formatted using the [`black` package](https://black.readthedocs.io/en/stable/). 