### PR TITLE
ensure string is returned

### DIFF
--- a/cnv2igv/1.3/cnv2igv.py
+++ b/cnv2igv/1.3/cnv2igv.py
@@ -165,7 +165,7 @@ class BattenbergParser(Parser):
                 loh_flag = '1'
         elif self.loh_type == 'any':
             if nMin1_A == 'NA':
-                loh_flag = 0
+                loh_flag = '0'
             elif float(nMin1_A) == 0:
                 loh_flag = '1'
         return(loh_flag)


### PR DESCRIPTION
Previously, in some cases integer was returned was loh flag in some segments for battenberg sugclones. This was causing the script to fail. This update will ensure the string is always returned. No version number update is required.