### PR TITLE
bug fix: handle cnvkit outputs

### DIFF
--- a/fill_segments/1.0/fill_segments.sh
+++ b/fill_segments/1.0/fill_segments.sh
@@ -86,7 +86,7 @@ fi
 
 
 # Merge the initial seg file with the missing segments and rearrange columns to match the style of seg files
-cat $RESULTS_PATH.headerless.bed $RESULTS_PATH.temp | sort -k1,1 -k2,2n -V  > $RESULTS_PATH.merged.seg
+cat $RESULTS_PATH.headerless.bed $RESULTS_PATH.temp | sort -k1,1 -k2,2n -V | perl -lane 'print if ($F[2]-$F[1])>1;' > $RESULTS_PATH.merged.seg
 
 # Now, remove blacklisted regions (centromeres and p arm telomeres) from this file.
 


### PR DESCRIPTION
Some cnvkit outputs are generating negative segments, where the end is less than the start of the segment. This update ensures to filter these out because they make the bedtools exit with error. 