### PR TITLE
Updated salmon2counts environment recipe

### DIFF
--- a/salmon2counts/1.0/salmon2counts.yaml
+++ b/salmon2counts/1.0/salmon2counts.yaml
@@ -18,7 +18,7 @@ dependencies:
   - bioconductor-biostrings=2.56.0
   - bioconductor-delayedarray=0.14.0
   - bioconductor-genomeinfodb=1.24.0
-  - bioconductor-genomeinfodbdata=1.2.3
+  - bioconductor-genomeinfodbdata=1.2.4
   - bioconductor-genomicalignments=1.24.0
   - bioconductor-genomicfeatures=1.40.0
   - bioconductor-genomicranges=1.40.0


### PR DESCRIPTION
It appears that bioconductor-genomeinfodbdata 1.2.3 is no longer available on bioconda. I've updated the dependency version to 1.2.4