### PR TITLE
Generate smr fix for case when there are no overlaps

### DIFF
--- a/generate_smr_inputs/1.0/generate_smr_inputs.R
+++ b/generate_smr_inputs/1.0/generate_smr_inputs.R
@@ -155,9 +155,7 @@ solve_overlap = function(seg) {
     non_overlap = seg[-num_pre_overlap_sorted,]
     seg <- seg[num_pre_overlap_sorted,]
     for (i in 1:nrow(seg)) {
-      if (nrow(seg) == 0) {
-        break
-      }else if (seg$overlap_status[i] == "overlap") {
+      if (seg$overlap_status[i] == "overlap") {
           if (seg$end[i] < seg$end[i-1]){
               new_row1 <- data.frame(ID = seg$ID[i],
                                       chrom = seg$chrom[i],
@@ -260,7 +258,14 @@ solve_overlap = function(seg) {
 }
 
 full_seg_checked <- check_overlap(full_seg)
-full_seg <- solve_overlap(full_seg_checked)
+# if no overlaps, do not run solve function
+if ("overlap" %in% full_seg_checked$overlap_status) {
+  full_seg <- solve_overlap(full_seg_checked)
+} else {
+  full_seg <- full_seg_checked %>%
+  select(-overlap_status, -region_size)
+}
+
 
 # Report missing samples -------------------
 missing_samples <- setdiff(case_set_samples,

--- a/generate_smr_inputs/1.0/generate_smr_inputs.R
+++ b/generate_smr_inputs/1.0/generate_smr_inputs.R
@@ -155,95 +155,97 @@ solve_overlap = function(seg) {
     non_overlap = seg[-num_pre_overlap_sorted,]
     seg <- seg[num_pre_overlap_sorted,]
     for (i in 1:nrow(seg)) {
-        if (seg$overlap_status[i] == "overlap") {
-            if (seg$end[i] < seg$end[i-1]){
-                new_row1 <- data.frame(ID = seg$ID[i],
-                                       chrom = seg$chrom[i],
-                                       start = seg$start[i-1],
-                                       end = seg$start[i],
-                                       LOH_flag = seg$LOH_flag[i-1],
-                                       log.ratio = seg$log.ratio[i-1],
-                                       overlap_status = "NOToverlap",
-                                       region_size = "FALSE")
-                new_row2 <- data.frame(ID = seg$ID[i],
-                                       chrom = seg$chrom[i],
-                                       start = seg$end[i],
-                                       end = seg$end[i-1],
-                                       LOH_flag = seg$LOH_flag[i-1],
-                                       log.ratio = seg$log.ratio[i-1],
-                                       overlap_status = "NOToverlap",
-                                       region_size = "FALSE")
-                seg <- seg[-(i-1), ]
-                seg <- rbind(seg, new_row1, new_row2)
-            }else if (seg$start[i-1] == seg$start[i]) {
-                new_row  <- data.frame(ID = seg$ID[i],
-                                       chrom = seg$chrom[i],
-                                       start = seg$end[i-1],
-                                       end = seg$end[i],
-                                       LOH_flag = seg$LOH_flag[i],
-                                       log.ratio = seg$log.ratio[i],
-                                       overlap_status = "NOToverlap",
-                                       region_size = "FALSE")
-                seg <- seg[-(i), ]
-                seg <- rbind(seg, new_row)
-            }else if (seg$region_size[i] < seg$region_size[i-1]) {
-                new_row1 <- data.frame(ID = seg$ID[i],
-                                       chrom = seg$chrom[i],
-                                       start = seg$start[i-1],
-                                       end = seg$start[i],
-                                       LOH_flag = seg$LOH_flag[i-1],
-                                       log.ratio = seg$log.ratio[i-1],
-                                       overlap_status = "NOToverlap",
-                                       region_size = "FALSE")
-                new_row2 <- data.frame(ID = seg$ID[i],
-                                       chrom = seg$chrom[i],
-                                       start = seg$start[i],
-                                       end = seg$end[i-1],
-                                       LOH_flag = seg$LOH_flag[i],
-                                       log.ratio = seg$log.ratio[i],
-                                       overlap_status = "NOToverlap",
-                                       region_size = "FALSE")
-                new_row3 <- data.frame(ID = seg$ID[i],
-                                       chrom = seg$chrom[i],
-                                       start = seg$end[i-1],
-                                       end = seg$end[i],
-                                       LOH_flag = seg$LOH_flag[i],
-                                       log.ratio = seg$log.ratio[i],
-                                       overlap_status = "NOToverlap",
-                                       region_size = "FALSE")
-                seg <- seg[-c(i, i-1), ]
-                seg <- rbind(seg, new_row1, new_row2, new_row3)
-            }else if (seg$region_size[i] > seg$region_size[i-1]) {
-                new_row1 <- data.frame(ID = seg$ID[i],
-                                       chrom = seg$chrom[i],
-                                       start = seg$start[i-1],
-                                       end = seg$start[i],
-                                       LOH_flag = seg$LOH_flag[i-1],
-                                       log.ratio = seg$log.ratio[i-1],
-                                       overlap_status = "NOToverlap",
-                                       region_size = "FALSE")
-                new_row2 <- data.frame(ID = seg$ID[i],
-                                       chrom = seg$chrom[i],
-                                       start = seg$start[i],
-                                       end = seg$end[i-1],
-                                       LOH_flag = seg$LOH_flag[i-1],
-                                       log.ratio = seg$log.ratio[i-1],
-                                       overlap_status = "NOToverlap",
-                                       region_size = "FALSE")
-                new_row3 <- data.frame(ID = seg$ID[i],
-                                       chrom = seg$chrom[i],
-                                       start = seg$end[i-1],
-                                       end = seg$end[i],
-                                       LOH_flag = seg$LOH_flag[i],
-                                       log.ratio = seg$log.ratio[i],
-                                       overlap_status = "NOToverlap",
-                                       region_size = "FALSE")
-                seg <- seg[-c(i, i-1), ]
-                seg <- rbind(seg, new_row1, new_row2, new_row3)
-            }
-        }
-        seg <- seg %>%
-        arrange(ID, chrom, start, end)
+      if (nrow(seg) == 0) {
+        break
+      }else if (seg$overlap_status[i] == "overlap") {
+          if (seg$end[i] < seg$end[i-1]){
+              new_row1 <- data.frame(ID = seg$ID[i],
+                                      chrom = seg$chrom[i],
+                                      start = seg$start[i-1],
+                                      end = seg$start[i],
+                                      LOH_flag = seg$LOH_flag[i-1],
+                                      log.ratio = seg$log.ratio[i-1],
+                                      overlap_status = "NOToverlap",
+                                      region_size = "FALSE")
+              new_row2 <- data.frame(ID = seg$ID[i],
+                                      chrom = seg$chrom[i],
+                                      start = seg$end[i],
+                                      end = seg$end[i-1],
+                                      LOH_flag = seg$LOH_flag[i-1],
+                                      log.ratio = seg$log.ratio[i-1],
+                                      overlap_status = "NOToverlap",
+                                      region_size = "FALSE")
+              seg <- seg[-(i-1), ]
+              seg <- rbind(seg, new_row1, new_row2)
+          }else if (seg$start[i-1] == seg$start[i]) {
+              new_row  <- data.frame(ID = seg$ID[i],
+                                      chrom = seg$chrom[i],
+                                      start = seg$end[i-1],
+                                      end = seg$end[i],
+                                      LOH_flag = seg$LOH_flag[i],
+                                      log.ratio = seg$log.ratio[i],
+                                      overlap_status = "NOToverlap",
+                                      region_size = "FALSE")
+              seg <- seg[-(i), ]
+              seg <- rbind(seg, new_row)
+          }else if (seg$region_size[i] < seg$region_size[i-1]) {
+              new_row1 <- data.frame(ID = seg$ID[i],
+                                      chrom = seg$chrom[i],
+                                      start = seg$start[i-1],
+                                      end = seg$start[i],
+                                      LOH_flag = seg$LOH_flag[i-1],
+                                      log.ratio = seg$log.ratio[i-1],
+                                      overlap_status = "NOToverlap",
+                                      region_size = "FALSE")
+              new_row2 <- data.frame(ID = seg$ID[i],
+                                      chrom = seg$chrom[i],
+                                      start = seg$start[i],
+                                      end = seg$end[i-1],
+                                      LOH_flag = seg$LOH_flag[i],
+                                      log.ratio = seg$log.ratio[i],
+                                      overlap_status = "NOToverlap",
+                                      region_size = "FALSE")
+              new_row3 <- data.frame(ID = seg$ID[i],
+                                      chrom = seg$chrom[i],
+                                      start = seg$end[i-1],
+                                      end = seg$end[i],
+                                      LOH_flag = seg$LOH_flag[i],
+                                      log.ratio = seg$log.ratio[i],
+                                      overlap_status = "NOToverlap",
+                                      region_size = "FALSE")
+              seg <- seg[-c(i, i-1), ]
+              seg <- rbind(seg, new_row1, new_row2, new_row3)
+          }else if (seg$region_size[i] > seg$region_size[i-1]) {
+              new_row1 <- data.frame(ID = seg$ID[i],
+                                      chrom = seg$chrom[i],
+                                      start = seg$start[i-1],
+                                      end = seg$start[i],
+                                      LOH_flag = seg$LOH_flag[i-1],
+                                      log.ratio = seg$log.ratio[i-1],
+                                      overlap_status = "NOToverlap",
+                                      region_size = "FALSE")
+              new_row2 <- data.frame(ID = seg$ID[i],
+                                      chrom = seg$chrom[i],
+                                      start = seg$start[i],
+                                      end = seg$end[i-1],
+                                      LOH_flag = seg$LOH_flag[i-1],
+                                      log.ratio = seg$log.ratio[i-1],
+                                      overlap_status = "NOToverlap",
+                                      region_size = "FALSE")
+              new_row3 <- data.frame(ID = seg$ID[i],
+                                      chrom = seg$chrom[i],
+                                      start = seg$end[i-1],
+                                      end = seg$end[i],
+                                      LOH_flag = seg$LOH_flag[i],
+                                      log.ratio = seg$log.ratio[i],
+                                      overlap_status = "NOToverlap",
+                                      region_size = "FALSE")
+              seg <- seg[-c(i, i-1), ]
+              seg <- rbind(seg, new_row1, new_row2, new_row3)
+          }
+      }
+      seg <- seg %>%
+      arrange(ID, chrom, start, end)
     }
     seg = seg %>% arrange(ID, chrom, start, end) 
     seg = check_overlap(seg)


### PR DESCRIPTION
Function that solves overlapping regions will error if there are no overlapping regions in the seg file.
I added a condition to skip running the function if there are no overlaps.
I tested this on a case_set where there are no overlaps.