### PR TITLE
read categories while ignoring comments

### DIFF
--- a/generate_smr_inputs/1.0/generate_smr_inputs.R
+++ b/generate_smr_inputs/1.0/generate_smr_inputs.R
@@ -51,7 +51,7 @@ metadata <- data.frame(sample_id=metadata_str[c(TRUE,FALSE,FALSE,FALSE,FALSE,FAL
 metadata <- metadata %>%  
   mutate_all(~na_if(., ''))
 
-full_subsetting_categories <- suppressMessages(read_tsv(subsetting_categories_file))
+full_subsetting_categories <- suppressMessages(read_tsv(subsetting_categories_file, comment="#"))
 
 # Get subsetting values for the case_set
 subsetting_values <- full_subsetting_categories %>%


### PR DESCRIPTION
Added a description to `data/metadata/level3_subsetting_categories.tsv` so this code will ignore those lines when reading in the table.