### PR TITLE
Fill subclone segments with NA

### DIFF
--- a/fill_segments/1.0/fill_segments.sh
+++ b/fill_segments/1.0/fill_segments.sh
@@ -81,7 +81,7 @@ elif [[ "$MODE" == *"subclones"* ]]; then
     # Make variable available to use within perl
     export NUM_COLUMNS
     bedtools subtract -a $ARM_BED_PATH -b $RESULTS_PATH.headerless.bed \
-    | perl -lane '@a=split;$a[1] = ++$a[1];$a[2] = --$a[2]; $a[3]="0.5"; $a[4]="1.0"; $a[5]="0.00"; $a[6]="2.0"; foreach my $column (7..12) {$a[$column]="1.0"}; foreach my $column (13..$ENV{NUM_COLUMNS}) {$a[$column]="NA"}; print join "\t", @a;' > $RESULTS_PATH.temp
+    | perl -lane '@a=split;$a[1] = ++$a[1];$a[2] = --$a[2]; $a[3]="0.5"; $a[4]="1.0"; $a[5]="0.00"; $a[6]="2.0"; foreach my $column (7..9) {$a[$column]="1.0"}; foreach my $column (10..$ENV{NUM_COLUMNS}) {$a[$column]="NA"}; print join "\t", @a;' > $RESULTS_PATH.temp
 
 elif [[ "$MODE" == *"sequenza"* ]]; then
     # Make variable available to use within perl

--- a/fill_segments/1.0/fill_segments.sh
+++ b/fill_segments/1.0/fill_segments.sh
@@ -81,7 +81,7 @@ elif [[ "$MODE" == *"subclones"* ]]; then
     # Make variable available to use within perl
     export NUM_COLUMNS
     bedtools subtract -a $ARM_BED_PATH -b $RESULTS_PATH.headerless.bed \
-    | perl -lane '@a=split;$a[1] = ++$a[1];$a[2] = --$a[2]; $a[3]="0.5"; $a[4]="1.0"; $a[5]="0.00"; $a[6]="2.0"; foreach my $column (7..9) {$a[$column]="1.0"}; foreach my $column (10..$ENV{NUM_COLUMNS}) {$a[$column]="NA"}; print join "\t", @a;' > $RESULTS_PATH.temp
+    | perl -lane '@a=split;$a[1] = ++$a[1];$a[2] = --$a[2]; $a[3]="0.5"; $a[4]="1.0"; $a[5]="0.00"; $a[6]="2.0"; foreach my $column (7..12) {$a[$column]="1.0"}; foreach my $column (13..$ENV{NUM_COLUMNS}) {$a[$column]="NA"}; print join "\t", @a;' > $RESULTS_PATH.temp
 
 elif [[ "$MODE" == *"sequenza"* ]]; then
     # Make variable available to use within perl


### PR DESCRIPTION
Previously, these columns in Battenberg `*subclones_filled.txt` output were set to
```
nMaj1_A	nMin1_A	frac1_A	nMaj2_A	nMin2_A	frac2_A
1.0	1.0	1.0	1.0	1.0	1.0
```
However, the Battenberg documentation says `nMaj2_A nMin2_A frac2_A` are only filled with values when the segment has more than one state (clonal and subclonal), so the `frac1_A` and `frac2_A` should add to one.

This PR sets these columns to
```
nMaj1_A	nMin1_A	frac1_A	nMaj2_A	nMin2_A	frac2_A
1.0	1.0	1.0	NA	NA	NA
```