### PR TITLE
Prepare smg script takes in metadata shape

### DIFF
--- a/fill_segments/1.0/fill_segments.sh
+++ b/fill_segments/1.0/fill_segments.sh
@@ -81,7 +81,7 @@ elif [[ "$MODE" == *"subclones"* ]]; then
     # Make variable available to use within perl
     export NUM_COLUMNS
     bedtools subtract -a $ARM_BED_PATH -b $RESULTS_PATH.headerless.bed \
-    | perl -lane '@a=split;$a[1] = ++$a[1];$a[2] = --$a[2]; $a[3]="0.5"; $a[4]="1.0"; $a[5]="0.00"; $a[6]="2.0"; foreach my $column (7..12) {$a[$column]="1.0"}; foreach my $column (13..$ENV{NUM_COLUMNS}) {$a[$column]="NA"}; print join "\t", @a;' > $RESULTS_PATH.temp
+    | perl -lane '@a=split;$a[1] = ++$a[1];$a[2] = --$a[2]; $a[3]="0.5"; $a[4]="1.0"; $a[5]="0.00"; $a[6]="2.0"; foreach my $column (7..9) {$a[$column]="1.0"}; foreach my $column (10..$ENV{NUM_COLUMNS}) {$a[$column]="NA"}; print join "\t", @a;' > $RESULTS_PATH.temp
 
 elif [[ "$MODE" == *"sequenza"* ]]; then
     # Make variable available to use within perl

--- a/fill_segments/1.0/fill_segments.sh
+++ b/fill_segments/1.0/fill_segments.sh
@@ -81,7 +81,7 @@ elif [[ "$MODE" == *"subclones"* ]]; then
     # Make variable available to use within perl
     export NUM_COLUMNS
     bedtools subtract -a $ARM_BED_PATH -b $RESULTS_PATH.headerless.bed \
-    | perl -lane '@a=split;$a[1] = ++$a[1];$a[2] = --$a[2]; $a[3]="0.5"; $a[4]="1.0"; $a[5]="0.00"; $a[6]="2.0"; foreach my $column (7..9) {$a[$column]="1.0"}; foreach my $column (10..$ENV{NUM_COLUMNS}) {$a[$column]="NA"}; print join "\t", @a;' > $RESULTS_PATH.temp
+    | perl -lane '@a=split;$a[1] = ++$a[1];$a[2] = --$a[2]; $a[3]="0.5"; $a[4]="1.0"; $a[5]="0.00"; $a[6]="2.0"; foreach my $column (7..12) {$a[$column]="1.0"}; foreach my $column (13..$ENV{NUM_COLUMNS}) {$a[$column]="NA"}; print join "\t", @a;' > $RESULTS_PATH.temp
 
 elif [[ "$MODE" == *"sequenza"* ]]; then
     # Make variable available to use within perl

--- a/generate_smg_inputs/1.1/generate_smg_inputs.R
+++ b/generate_smg_inputs/1.1/generate_smg_inputs.R
@@ -46,6 +46,7 @@ if ("maf" %in% names(snakemake@input)){
 
 meta <- snakemake@params[['metadata']]
 meta_cols <- snakemake@params[['metadata_cols']]
+meta_shape <- snakemake@params[['metadata_dim']]
 
 cat("Arguments from snakemake...\n")
 cat(paste("Sample sets file:", subsetting_categories_file, "\n"))
@@ -63,8 +64,7 @@ if ("seg" %in% names(snakemake@input)){
 # Determine sample ids in sample set -----------------------------------------------------
 # pandas df from snakemake is passed as a character vector
 # This converts it into a dataframe
-num_rows <- length(meta)/length(meta_cols)
-meta_matrix <- t(matrix(meta, nrow = 25, ncol = num_rows))
+meta_matrix <- t(matrix(meta, nrow = meta_shape[2], ncol = meta_shape[1]))
 # Format NA
 meta_matrix[meta_matrix==""] <- NA
 # Convert to dataframe and name columns

--- a/generate_smg_inputs/1.1/generate_smg_inputs.R
+++ b/generate_smg_inputs/1.1/generate_smg_inputs.R
@@ -25,13 +25,8 @@ suppressPackageStartupMessages({
 })
 )
 
-# Get threads SLURM parameter if not running locally -----------------------------------------------------
-if (Sys.getenv("SLURM_CPUS_PER_TASK") == ""){
-  threads <- 1
-}else {
-  threads <- strtoi(Sys.getenv("SLURM_CPUS_PER_TASK"))
-  cat(paste("threads: ", threads, "\n"))
-}
+# Reading in large marf/seg files is more efficient when uses more than one thread -----------------------------------------------------
+threads <- 4
 
 # Determine arguments from snakemake -----------------------------------------------------
 subsetting_categories_file <- snakemake@input[["subsetting_categories"]]

--- a/generate_smg_inputs/1.1/generate_smg_inputs.R
+++ b/generate_smg_inputs/1.1/generate_smg_inputs.R
@@ -37,6 +37,7 @@ sample_set <- snakemake@wildcards[["sample_set"]]
 launch_date <- snakemake@wildcards[["launch_date"]]
 
 mode <- snakemake@params[["mode"]]
+
 if ("maf" %in% names(snakemake@input)){
   include_non_coding <- snakemake@params[["include_non_coding"]]
 } else if ("seg" %in% names(snakemake@input)){
@@ -150,7 +151,6 @@ if ("genome" %in% subsetting_values$seq_type && !("capture" %in% subsetting_valu
                                                 col_select = all_of(relevant_maf_columns),
                                                 num_threads = threads))
     }
-
   } else if ("seg" %in% names(snakemake@input)){
     genome_input <- suppressMessages(read_tsv(input_files[str_detect(input_files, "genome")], num_threads = threads))
   }
@@ -159,11 +159,11 @@ if ("genome" %in% subsetting_values$seq_type && !("capture" %in% subsetting_valu
   if ("maf" %in% names(snakemake@input)){
     subset_input <- genome_input %>%
       filter(Tumor_Sample_Barcode %in% this_subset_samples)
-
   } else if ("seg" %in% names(snakemake@input)) {
     subset_input <- genome_input %>%
       filter(ID %in% this_subset_samples)
   }
+
 } else if (!("genome" %in% subsetting_values$seq_type) && "capture" %in% subsetting_values$seq_type) { # capture only
   cat("Loading capture input file...\n")
   if ("maf" %in% names(snakemake@input)){
@@ -178,11 +178,11 @@ if ("genome" %in% subsetting_values$seq_type && !("capture" %in% subsetting_valu
   if ("maf" %in% names(snakemake@input)){
     subset_input <- capture_input %>%
       filter(Tumor_Sample_Barcode %in% this_subset_samples)
-
   } else if ("seg" %in% names(snakemake@input)) {
     subset_input <- capture_input %>%
       filter(ID %in% this_subset_samples)
   }
+
 } else if ("genome" %in% subsetting_values$seq_type && "capture" %in% subsetting_values$seq_type) { # both
   cat("Loading genome input file ...\n")
   if ("maf" %in% names(snakemake@input)){
@@ -211,7 +211,7 @@ if ("genome" %in% subsetting_values$seq_type && !("capture" %in% subsetting_valu
       filter(!Tumor_Sample_Barcode %in% unique(genome_subset$Tumor_Sample_Barcode)) %>%
       filter(Tumor_Sample_Barcode %in% this_subset_samples)
 
-    subset_input <- rbind(genome_subset, capture_subset)
+    subset_input <- bind_rows(genome_subset, capture_subset)
 
   } else if ("seg" %in% names(snakemake@input)) {
     genome_subset <- genome_input %>%
@@ -221,7 +221,7 @@ if ("genome" %in% subsetting_values$seq_type && !("capture" %in% subsetting_valu
       filter(!ID %in% unique(genome_subset$ID)) %>%
       filter(ID %in% this_subset_samples)
 
-    subset_input <- rbind(genome_subset, capture_subset)
+    subset_input <- bind_rows(genome_subset, capture_subset)
   }
 }
 
@@ -560,7 +560,6 @@ if ("maf" %in% names(snakemake@input)){
 
 } else if ("seg" %in% names(snakemake@input)){
   cat("Writing combined seg data to file... \n")
-  subset_input
   write_tsv(subset_input, paste0(output_dir, "/", md5sum, ".seg"))
 
   cat("Writing sample ids to file... \n")


### PR DESCRIPTION
Errors arose from the GAMBL metadata having columns added recently. The number of column was hard coded to 25. Now the dimensions of the metadata are passed as a parameter, which is used to build the dataframe in R. 

This was tested with module fishhook. The changes will be implemented to the other level3 modules in a coming PR.