### PR TITLE
Add starfish 2.0 container

### DIFF
--- a/starfish/2.0/Dockerfile
+++ b/starfish/2.0/Dockerfile
@@ -4,11 +4,10 @@ LABEL org.opencontainers.image.source="https://github.com/LCR-BCCRC/lcr-scripts"
 RUN mamba install --yes --name base \
         --channel bioconda \
         --channel conda-forge \
-        libxml2 \
         pysam \
         matplotlib \
         bcftools \
         rtg-tools \
-    && mamba clean --all --yes
+    && rm -rf /opt/conda/pkgs/*
 
 CMD ["/bin/bash"]

--- a/starfish/2.0/Dockerfile
+++ b/starfish/2.0/Dockerfile
@@ -4,6 +4,7 @@ LABEL org.opencontainers.image.source="https://github.com/LCR-BCCRC/lcr-scripts"
 RUN mamba install --yes --name base \
         --channel bioconda \
         --channel conda-forge \
+        libxml2 \
         pysam \
         matplotlib \
         bcftools \

--- a/starfish/2.0/Dockerfile
+++ b/starfish/2.0/Dockerfile
@@ -1,0 +1,13 @@
+FROM condaforge/mambaforge:latest
+LABEL org.opencontainers.image.source="https://github.com/LCR-BCCRC/lcr-scripts"
+
+RUN mamba install --yes --name base \
+        --channel bioconda \
+        --channel conda-forge \
+        pysam \
+        matplotlib \
+        bcftools \
+        rtg-tools \
+    && mamba clean --all --yes
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
Adds a Dockerfile to build a container for Starfish. Installs pysam, matplotlib, bcftools, and rtg-tools — the four runtime dependencies of starfish.py (Python imports + subprocess calls).