### PR TITLE
Add fill_segments 1.1 container with bedtools and perl

### DIFF
--- a/fill_segments/1.1/Dockerfile
+++ b/fill_segments/1.1/Dockerfile
@@ -1,0 +1,11 @@
+FROM condaforge/mambaforge:latest
+LABEL org.opencontainers.image.source="https://github.com/LCR-BCCRC/lcr-scripts"
+
+RUN mamba install --yes --name base \
+        --channel bioconda \
+        --channel conda-forge \
+        "bedtools=2.29.2" \
+        perl \
+    && rm -rf /opt/conda/pkgs/*
+
+CMD ["/bin/bash"]

--- a/fill_segments/1.1/run_tests.sh
+++ b/fill_segments/1.1/run_tests.sh
@@ -25,10 +25,10 @@ out_dir="${1:-tests/output}"
 mkdir -p "$out_dir"
 
 echo "testing seg mode"
-./fill_segments.sh $hg38_chrArms $in_dir/sequenza_segments.seg $hg38_blacklist $out_dir/sequenza_segments.filled.seg Sequenza_SAMPLE1 SEG
+bash fill_segments.sh $hg38_chrArms $in_dir/sequenza_segments.seg $hg38_blacklist $out_dir/sequenza_segments.filled.seg Sequenza_SAMPLE1 SEG
 
 echo "testing subclones mode"
-./fill_segments.sh $hg38_chrArms $in_dir/SP116712_subclones.txt $hg38_blacklist $out_dir/SP116712_subclones.filled.txt SP116712 subclones
+bash fill_segments.sh $hg38_chrArms $in_dir/SP116712_subclones.txt $hg38_blacklist $out_dir/SP116712_subclones.filled.txt SP116712 subclones
 
 echo "testing sequenza mode"
-./fill_segments.sh $hg38_chrArms $in_dir/sequenza_segments_with_NA.txt  $hg38_blacklist $out_dir/sequenza_segments_with_NA.filled.txt Sequenza_SAMPLE2 subclones
+bash fill_segments.sh $hg38_chrArms $in_dir/sequenza_segments_with_NA.txt  $hg38_blacklist $out_dir/sequenza_segments_with_NA.filled.txt Sequenza_SAMPLE2 subclones

--- a/fill_segments/1.1/run_tests.sh
+++ b/fill_segments/1.1/run_tests.sh
@@ -21,7 +21,8 @@ hg38_blacklist="src/blacklisted.hg38.bed"
 grch37_blacklist="src/blacklisted.grch37.bed"
 
 in_dir="tests/input"
-out_dir="tests/output"
+out_dir="${1:-tests/output}"
+mkdir -p "$out_dir"
 
 echo "testing seg mode"
 ./fill_segments.sh $hg38_chrArms $in_dir/sequenza_segments.seg $hg38_blacklist $out_dir/sequenza_segments.filled.seg Sequenza_SAMPLE1 SEG


### PR DESCRIPTION
The biocontainer for bedtools lacks perl, which fill_segments.sh requires for multiple column-manipulation one-liners throughout.