### PR TITLE
Add snpeff:1.0 container (snpeff 4.3.1t + bcftools 1.10.2)

### DIFF
--- a/snpeff/1.0/Dockerfile
+++ b/snpeff/1.0/Dockerfile
@@ -1,0 +1,11 @@
+FROM condaforge/mambaforge:latest
+LABEL org.opencontainers.image.source="https://github.com/LCR-BCCRC/lcr-scripts"
+
+RUN mamba install --yes --name base \
+        --channel bioconda \
+        --channel conda-forge \
+        "snpeff=4.3.1t" \
+        "bcftools=1.10.2" \
+    && rm -rf /opt/conda/pkgs/*
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
Used by hmftools modules where snpEff output is piped directly to bcftools in the same shell command, requiring both tools in one container.