### PR TITLE
Update battenberg 1.1 to pin 7a74124 (mclapply + ifelse fix)

### DIFF
--- a/battenberg/1.1/Dockerfile
+++ b/battenberg/1.1/Dockerfile
@@ -14,6 +14,6 @@ RUN mamba install --yes --name base \
     && rm -rf /opt/conda/pkgs/*
 
 RUN R --vanilla -q -e 'remotes::install_github("morinlab/ascat/ASCAT", lib="/opt/conda/lib/R/library", dependencies = TRUE, upgrade = "never")' \
-    && R --vanilla -q -e 'remotes::install_github("morinlab/battenberg@db2fbb7", lib="/opt/conda/lib/R/library", dependencies = TRUE, upgrade = "never")'
+    && R --vanilla -q -e 'remotes::install_github("morinlab/battenberg@7a74124", lib="/opt/conda/lib/R/library", dependencies = TRUE, upgrade = "never")'
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
db2fbb7 has the ifelse fix but uses the older foreach/doParallel approach (chromosomes in parallel, chunks sequential). 7a74124 is the subsequent commit that refactors to mclapply within each chromosome (chromosomes sequential, chunks parallel) while retaining the ifelse fix.