### PR TITLE
Add bedtools 2.31.1 container based on mambaforge (Debian)

### DIFF
--- a/bedtools/2.31.1/Dockerfile
+++ b/bedtools/2.31.1/Dockerfile
@@ -1,0 +1,10 @@
+FROM condaforge/mambaforge:latest
+LABEL org.opencontainers.image.source="https://github.com/LCR-BCCRC/lcr-scripts"
+
+RUN mamba install --yes --name base \
+        --channel bioconda \
+        --channel conda-forge \
+        "bedtools=2.31.1" \
+    && rm -rf /opt/conda/pkgs/*
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
biocontainers/bedtools images use Alpine/BusyBox sort which lacks --parallel support. This Debian-based image provides GNU coreutils sort and comm alongside bedtools.