### PR TITLE
Fix sequenza 3.0.0 container: pin r-iotools=0.3_1

### DIFF
--- a/sequenza/3.0.0/Dockerfile
+++ b/sequenza/3.0.0/Dockerfile
@@ -5,6 +5,7 @@ RUN mamba install --yes --name base \
         --channel bioconda \
         --channel conda-forge \
         "r-sequenza=3.0.0" \
+        "r-iotools=0.3_1" \
         r-remotes \
     && rm -rf /opt/conda/pkgs/*
 


### PR DESCRIPTION
Newer iotools dropped the parallel= argument from chunk.apply, which r-sequenza 3.0.0 passes via gc.sample.stats. Pin to 0.3_1 to match the conda env.