### PR TITLE
Add picard 2.22.3 container with pigz for parallel compression

### DIFF
--- a/picard/2.22.3/Dockerfile
+++ b/picard/2.22.3/Dockerfile
@@ -1,0 +1,11 @@
+FROM condaforge/mambaforge:latest
+LABEL org.opencontainers.image.source="https://github.com/LCR-BCCRC/lcr-scripts"
+
+RUN mamba install --yes --name base \
+        --channel bioconda \
+        --channel conda-forge \
+        "picard=2.22.3" \
+        "pigz" \
+    && rm -rf /opt/conda/pkgs/*
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
Replaces quay.io/biocontainers/picard:2.22.3--0 with a custom container that includes pigz so bam2fastq can use multi-threaded compression.