### PR TITLE
Fix mawk-incompatible interval expressions in fill_segments 1.2

### DIFF
--- a/battenberg/1.1/Dockerfile
+++ b/battenberg/1.1/Dockerfile
@@ -14,6 +14,6 @@ RUN mamba install --yes --name base \
     && rm -rf /opt/conda/pkgs/*
 
 RUN R --vanilla -q -e 'remotes::install_github("morinlab/ascat/ASCAT", lib="/opt/conda/lib/R/library", dependencies = TRUE, upgrade = "never")' \
-    && R --vanilla -q -e 'remotes::install_github("morinlab/battenberg@7a74124", lib="/opt/conda/lib/R/library", dependencies = TRUE, upgrade = "never")'
+    && R --vanilla -q -e 'remotes::install_github("morinlab/battenberg@ff0f570", lib="/opt/conda/lib/R/library", dependencies = TRUE, upgrade = "never")'
 
 CMD ["/bin/bash"]

--- a/fill_segments/1.2/fill_segments.sh
+++ b/fill_segments/1.2/fill_segments.sh
@@ -139,13 +139,13 @@ fi
 # Prefix of output is set to match that of the chrom arms file earlier in this script
 # so we can use $ARM_IS_PREFIXED as a way to tell if the output is prefixed
 if [[ "$MODE" == *"SEG"* && "$ARM_IS_PREFIXED" == *"chr"* ]]; then
-    awk -F"\t" -v OFS="\t" '$2 ~ /^chrom$|^chr[0-9]{1,2}$|^chr(X|Y)$/ {print}' $RESULTS_PATH.allchrms.seg > $RESULTS_PATH
+    awk -F"\t" -v OFS="\t" '$2 ~ /^chrom$|^chr[0-9][0-9]?$|^chr(X|Y)$/ {print}' $RESULTS_PATH.allchrms.seg > $RESULTS_PATH
 elif [[ "$MODE" == *"SEG"* && ! "$ARM_IS_PREFIXED" == *"chr"* ]]; then
-    awk -F"\t" -v OFS="\t" '$2 ~ /^chrom$|^[0-9]{1,2}$|^(X|Y)$/ {print}' $RESULTS_PATH.allchrms.seg > $RESULTS_PATH
+    awk -F"\t" -v OFS="\t" '$2 ~ /^chrom$|^[0-9][0-9]?$|^(X|Y)$/ {print}' $RESULTS_PATH.allchrms.seg > $RESULTS_PATH
 elif [[ ! "$MODE" == *"SEG"* && "$ARM_IS_PREFIXED" == *"chr"* ]]; then
-    awk -F"\t" -v OFS="\t" '$1 ~ /^chromosome$|^chr$|^chr[0-9]{1,2}$|^chr(X|Y)$/ {print}' $RESULTS_PATH.allchrms.seg > $RESULTS_PATH
+    awk -F"\t" -v OFS="\t" '$1 ~ /^chromosome$|^chr$|^chr[0-9][0-9]?$|^chr(X|Y)$/ {print}' $RESULTS_PATH.allchrms.seg > $RESULTS_PATH
 elif [[ ! "$MODE" == *"SEG"* && ! "$ARM_IS_PREFIXED" == *"chr"* ]]; then
-    awk -F"\t" -v OFS="\t" '$1 ~ /^chromosome$|^chr$|^[0-9]{1,2}$|^(X|Y)$/ {print}' $RESULTS_PATH.allchrms.seg > $RESULTS_PATH
+    awk -F"\t" -v OFS="\t" '$1 ~ /^chromosome$|^chr$|^[0-9][0-9]?$|^(X|Y)$/ {print}' $RESULTS_PATH.allchrms.seg > $RESULTS_PATH
 fi
 
 


### PR DESCRIPTION
Replace awk {1,2} interval quantifiers with [0-9]? which is semantically
identical but supported by all awk implementations including mawk (the
default in many Debian/Ubuntu Docker containers).

Without this fix, ^chr[0-9]{1,2}$ silently matches nothing in mawk,
so only chrX/chrY pass the canonical-chromosome filter and all autosomes
are dropped from the output. Proven with fill_segments:1.1 container
(mawk) against SP116712_subclones.txt test data.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>