### PR TITLE
Update battenberg:1.1 to ace180b 

### DIFF
--- a/battenberg/1.1/Dockerfile
+++ b/battenberg/1.1/Dockerfile
@@ -14,6 +14,6 @@ RUN mamba install --yes --name base \
     && rm -rf /opt/conda/pkgs/*
 
 RUN R --vanilla -q -e 'remotes::install_github("morinlab/ascat/ASCAT", lib="/opt/conda/lib/R/library", dependencies = TRUE, upgrade = "never")' \
-    && R --vanilla -q -e 'remotes::install_github("morinlab/battenberg@ff0f570", lib="/opt/conda/lib/R/library", dependencies = TRUE, upgrade = "never")'
+    && R --vanilla -q -e 'remotes::install_github("morinlab/battenberg@ace180b", lib="/opt/conda/lib/R/library", dependencies = TRUE, upgrade = "never")'
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
(strip chr prefix from alleleCounter output) 
Picks up second fix: after adding chr prefix to the loci file so alleleCounter finds reads in chr-prefixed BAMs, strip the resulting chr prefix from the alleleCounter output so it matches the non-prefixed 1000G alleles data used by getBAFsAndLogRs downstream.