### PR TITLE
Add battenberg 1.2 container pinned to memory-optimized commit

### DIFF
--- a/battenberg/1.2/Dockerfile
+++ b/battenberg/1.2/Dockerfile
@@ -1,0 +1,19 @@
+FROM condaforge/mambaforge:latest
+LABEL org.opencontainers.image.source="https://github.com/LCR-BCCRC/lcr-scripts"
+
+RUN mamba install --yes --name base \
+        --channel conda-forge \
+        --channel bioconda \
+        r-base \
+        r-remotes \
+        r-optparse \
+        "impute2=2.3.2" \
+        cancerit-allelecount \
+        parallel \
+        perl \
+    && rm -rf /opt/conda/pkgs/*
+
+RUN R --vanilla -q -e 'remotes::install_github("morinlab/ascat/ASCAT", lib="/opt/conda/lib/R/library", dependencies = TRUE, upgrade = "never")' \
+    && R --vanilla -q -e 'remotes::install_github("morinlab/battenberg@479df6c", lib="/opt/conda/lib/R/library", dependencies = TRUE, upgrade = "never")'
+
+CMD ["/bin/bash"]

--- a/battenberg/1.2/run_tests.sh
+++ b/battenberg/1.2/run_tests.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Smoke tests for the battenberg container.
+# Verifies that all required tools and R packages are present and loadable.
+# Usage: ./run_tests.sh
+
+PASS=true
+
+check() {
+    local desc="$1"
+    local cmd="$2"
+    local output
+    output=$(eval "$cmd" 2>&1)
+    if [ $? -eq 0 ]; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc"
+        echo "$output" | sed 's/^/  /'
+        PASS=false
+    fi
+}
+
+check "alleleCounter is available"       "command -v alleleCounter"
+check "impute2 is available"             "command -v impute2"
+check "Rscript is available"             "command -v Rscript"
+check "R package Battenberg loads"       "Rscript --vanilla -e 'library(Battenberg)'"
+check "R package ASCAT loads"            "Rscript --vanilla -e 'library(ASCAT)'"
+check "R package optparse loads"         "Rscript --vanilla -e 'library(optparse)'"
+check "R package readr loads"            "Rscript --vanilla -e 'library(readr)'"
+
+$PASS


### PR DESCRIPTION
Pins morinlab/battenberg@479df6c which adds rm()/gc() calls to reduce heap size before mclapply forks, and casts allele count columns to integer. Tagged as battenberg:1.2 to preserve the working battenberg:1.1 image for rollback if needed.