### PR TITLE
Update battenberg:1.2 to a4eab21 (PSOCK cluster parallelism)

### DIFF
--- a/battenberg/1.2/Dockerfile
+++ b/battenberg/1.2/Dockerfile
@@ -14,6 +14,6 @@ RUN mamba install --yes --name base \
     && rm -rf /opt/conda/pkgs/*
 
 RUN R --vanilla -q -e 'remotes::install_github("morinlab/ascat/ASCAT", lib="/opt/conda/lib/R/library", dependencies = TRUE, upgrade = "never")' \
-    && R --vanilla -q -e 'remotes::install_github("morinlab/battenberg@479df6c", lib="/opt/conda/lib/R/library", dependencies = TRUE, upgrade = "never")'
+    && R --vanilla -q -e 'remotes::install_github("morinlab/battenberg@a4eab21", lib="/opt/conda/lib/R/library", dependencies = TRUE, upgrade = "never")'
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Pins to the commit that replaces mclapply fork-based parallelism with a PSOCK cluster in run.impute, eliminating ~23 GB heap inheritance per impute2 worker.