### PR TITLE
Install VEP 100.2 from GitHub source to bypass Perl conflict

### DIFF
--- a/vcf2maf/1.6.18/Dockerfile
+++ b/vcf2maf/1.6.18/Dockerfile
@@ -5,7 +5,16 @@ RUN mamba install --yes --name base \
         --channel conda-forge \
         --channel bioconda \
         "vcf2maf=1.6.18" \
-        "ensembl-vep" \
-    && rm -rf /opt/conda/pkgs/*
+        "samtools" \
+        "perl-bioperl" \
+        "perl-set-intervaltree" \
+        "perl-perlio-gzip" \
+        "perl-archive-zip" \
+    && mamba clean -afy
+
+# VEP 100.2 from source — bypasses bioconda's Perl 5.26 packaging conflict
+RUN git clone --branch release/100 --depth 1 \
+        https://github.com/Ensembl/ensembl-vep.git /opt/vep \
+    && ln -s /opt/vep/vep /opt/conda/bin/vep
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
bioconda's ensembl-vep=100.2 package requires perl<5.26.3 but perl-bioperl transitively requires perl>=5.32.1, making it unresolvable. Installing VEP scripts from GitHub and Perl dependencies separately avoids the solver.

Also adds samtools from bioconda (biocontainer's bundled samtools was broken due to missing libcrypto.so.1.0.0).