### PR TITLE
Simplify: vcf2maf + samtools only, no VEP in container

### DIFF
--- a/vcf2maf/1.6.18/Dockerfile
+++ b/vcf2maf/1.6.18/Dockerfile
@@ -6,15 +6,6 @@ RUN mamba install --yes --name base \
         --channel bioconda \
         "vcf2maf=1.6.18" \
         "samtools" \
-        "perl-bioperl" \
-        "perl-set-intervaltree" \
-        "perl-perlio-gzip" \
-        "perl-archive-zip" \
     && mamba clean -afy
-
-# VEP 100.2 from source — bypasses bioconda's Perl 5.26 packaging conflict
-RUN git clone --branch release/100 --depth 1 \
-        https://github.com/Ensembl/ensembl-vep.git /opt/vep \
-    && ln -s /opt/vep/vep /opt/conda/bin/vep
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
VEP is provided by the host installation via vep_path config option, so it does not need to be bundled. samtools from bioconda replaces the biocontainer's broken samtools (missing libcrypto.so.1.0.0).