### PR TITLE
Add Dockerfile for SAGE 5.0 container

### DIFF
--- a/sage/5.0/Dockerfile
+++ b/sage/5.0/Dockerfile
@@ -1,0 +1,11 @@
+FROM condaforge/mambaforge:latest
+LABEL org.opencontainers.image.source="https://github.com/LCR-BCCRC/lcr-scripts"
+
+RUN mamba install --yes --name base \
+        --channel conda-forge \
+        --channel bioconda \
+        "hmftools-sage=5.0" \
+        htslib \
+    && rm -rf /opt/conda/pkgs/*
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
Installs hmftools-sage=5.0 and htslib (for bgzip) via mamba. The -skip_bqr and -skip_msi_jitter flags in the lcr-modules sage/1.2 module bypass the REDUX file requirements so this image works without pre-existing REDUX outputs.